### PR TITLE
Add setup config to image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM vault
 COPY docker-entrypoint.sh usr/local/bin/docker-entrypoint.sh
 COPY data/config.hcl /vault/config/config.hcl
+COPY data/setup.json /vault/setup/setup.json
 COPY * ./
 CMD ["server"]

--- a/data/setup.json
+++ b/data/setup.json
@@ -1,0 +1,14 @@
+{
+    "disable_mlock": 1,
+    "storage": {
+        "file": {
+            "path": "/vault/file"
+        }
+    },
+    "listener": {
+        "tcp": {
+            "address": "0.0.0.0:8200",
+            "tls_disable": 1
+        }
+    }
+}

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -32,7 +32,7 @@ fi
 # VAULT_CONFIG_DIR isn't exposed as a volume but you can compose additional
 # config files in there if you use this image as a base, or use
 # VAULT_LOCAL_CONFIG below.
-VAULT_CONFIG_DIR=/vault/config
+VAULT_CONFIG_DIR=${VAULT_CONFIG_DIR:-/vault/config}
 
 # You can also set the VAULT_LOCAL_CONFIG environment variable to pass some
 # Vault configuration JSON without having to bind any volumes.


### PR DESCRIPTION
As a part of moving to a migration based installation (rather than an installer script that does anything), Vault needed a to have a config that allows other containers to connect sans SSL. You can see how the installer utilizes this setup config in [TechnoCore/installer/bash/vault.sh](https://github.com/SciFiFarms/TechnoCore/blob/master/installer/bash/vault.sh). 